### PR TITLE
added GameGear to enum ConsoleID

### DIFF
--- a/RALibretro/src/RA_Integration/RA_Interface.h
+++ b/RALibretro/src/RA_Integration/RA_Interface.h
@@ -52,7 +52,7 @@ enum ConsoleID
   PlayStation,
   Lynx,
   NeoGeo,
-  Xbox360,
+  GameGear,
   GameCube,
   Jaguar,
   DS,


### PR DESCRIPTION
This solves a compilation error:
```
src/Emulator.h:64:21: error: 'GameGear' was not declared in this scope
```