### PR TITLE
menu.rc: Final Burn Alpha (Arcade) - not NeoGeo

### DIFF
--- a/RALibretro/src/menu.rc
+++ b/RALibretro/src/menu.rc
@@ -41,7 +41,7 @@ main MENU
         {
             MENUITEM "Beetle SGX (PC Engine)", IDM_SYSTEM_BEETLESGX
             MENUITEM "FCEUmm (Nintendo)", IDM_SYSTEM_FCEUMM
-            MENUITEM "Final Burn Alpha (Neo Geo)", IDM_SYSTEM_FBALPHA
+            MENUITEM "Final Burn Alpha (Arcade)", IDM_SYSTEM_FBALPHA
             MENUITEM "Gambatte (Game Boy, Game Boy Color)", IDM_SYSTEM_GAMBATTE
             MENUITEM "Genesis Plus GX (Game Gear, Master System, Mega Drive)", IDM_SYSTEM_GENESISPLUSGX
             MENUITEM "Handy (Atari Lynx)", IDM_SYSTEM_HANDY


### PR DESCRIPTION
We're going to use Final Burn Alpha for various Arcade drivers, not just Neo Geo, right?